### PR TITLE
Account speedups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
 
         <app.name>broker</app.name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
 
         <app.name>broker</app.name>
 
@@ -94,6 +94,14 @@
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                     <packagingExcludes>pom.xml</packagingExcludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/broker/BrokerService.java
+++ b/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/broker/BrokerService.java
@@ -166,26 +166,25 @@ public class BrokerService extends Application {
 
 			// Match up the accounts and portfolios
 			// TODO: Pagination should reduce the amount of work to do here
-			Map<String, Account> mapOfAccounts = Arrays.stream(accounts).collect(Collectors.toMap(Account::getOwner, account -> account));
-			Set<String> accountOwners = Arrays.stream(accounts).map(Account::getOwner).collect(Collectors.toSet());
+			Map<String, Account> mapOfAccounts = Arrays.stream(accounts).collect(Collectors.toMap(Account::get_id, account -> account));
+			Set<String> accountIds = Arrays.stream(accounts).map(Account::get_id).collect(Collectors.toSet());
 
 			brokersSet = Arrays.stream(portfolios)
 					.parallel()
-					.filter(portfolio -> accountOwners.contains(portfolio.getOwner()))
+					.filter(portfolio -> accountIds.contains(portfolio.getAccountID()))
 					.map(portfolio -> {
-						String owner = portfolio.getOwner();
+						String ownerId = portfolio.getAccountID();
 						// Don't log here, you'll get a NPE if you uncomment the following line
 						// logger.finer("Found account corresponding to the portfolio for " + owner);
-						return new Broker(portfolio, mapOfAccounts.get(owner));
+						return new Broker(portfolio, mapOfAccounts.get(ownerId));
 					})
 					.collect(Collectors.toSet());
 
 			// Now handle the cases where there is no matching account-portfolio mapping
 			brokersSet.addAll(Arrays.stream(portfolios)
 					.parallel()
-					.filter(Predicate.not(portfolio -> accountOwners.contains(portfolio.getOwner())))
+					.filter(Predicate.not(portfolio -> accountIds.contains(portfolio.getAccountID())))
 					.map(portfolio -> {
-						var owner = portfolio.getOwner();
 						// Don't log here, you'll get a NPE
 						// logger.finer("Did not find account corresponding to the portfolio for " + owner);
 						return new Broker(portfolio, null);


### PR DESCRIPTION
As part of our production readiness I've been doing some performance testing of end-to-end StockTrader: from `trader` to almost all microservices.  One item I discovered is that when there are approximately 200 portfolios in the database the response time to get all portfolios can slow down.  This is due to some nested loops in [BrokerService](https://github.com/IBMStockTrader/broker/blob/efdb2c147de9824045b11f9ef2f25acd700f9963/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/broker/BrokerService.java#L163-L180). On average, for 200 portfolios, these nested loops will fire approximately 14k times for a single "get portfolios" call, taking around 8 seconds to complete.

This fix uses Java Streams to parallelize these loops which gives a huge speed up: from 8 seconds to 90 ms.

A second PR will add in the OpenTracing that allowed me to find this slowdown.

**Note:** This PR is dependent on #7 