### PR TITLE
Update OpenLiberty to 22.0.0.3 and Java 17

### DIFF
--- a/.github/workflows/build-test-push-aws-ecr.yml
+++ b/.github/workflows/build-test-push-aws-ecr.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Setup Java
       uses: actions/setup-java@v1
       with:
-        java-version: 8
+        java-version: 17
         
     # Build and package app
     - name: Build and package app

--- a/.github/workflows/java-build-push-git-template.yaml
+++ b/.github/workflows/java-build-push-git-template.yaml
@@ -55,7 +55,7 @@ jobs:
     - name: Setup Java
       uses: actions/setup-java@v1
       with:
-        java-version: 8      
+        java-version: 17
   
     # Build and package app
     - name: Build and package app

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@
 # RUN mvn -f /usr/pom.xml clean package
 
 # FROM openliberty/open-liberty:kernel-slim-java11-openj9-ubi
-FROM openliberty/open-liberty:22.0.0.4-full-java17-openj9-ubi
+FROM openliberty/open-liberty:22.0.0.3-full-java17-openj9-ubi
 
 # ARG extract_keycloak_cert
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@
 # RUN mvn -f /usr/pom.xml clean package
 
 # FROM openliberty/open-liberty:kernel-slim-java11-openj9-ubi
-FROM openliberty/open-liberty:21.0.0.12-full-java11-openj9-ubi
+FROM openliberty/open-liberty:22.0.0.4-full-java17-openj9-ubi
 
 # ARG extract_keycloak_cert
 USER root

--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
 
         <app.name>broker</app.name>
 


### PR DESCRIPTION
There have been lots of JWT-related fixes in OpenLiberty since 21.0.0.12.  For example, when doing concurrent programming with WLP and JWTs on 21.0.0.12 I was getting:
```
SRVE0315E: An exception occurred: java.lang.Throwable: java.lang.NullPointerException
    at com.ibm.ws.webcontainer.webapp.WebApp.handleRequest(WebApp.java:5107)
    at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.handleRequest(DynamicVirtualHost.java:320)
    at com.ibm.ws.webcontainer.WebContainer.handleRequest(WebContainer.java:1007)
    at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.run(DynamicVirtualHost.java:285)
    at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink$TaskWrapper.run(HttpDispatcherLink.java:1184)
    at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.wrapHandlerAndExecute(HttpDispatcherLink.java:453)
    at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.ready(HttpDispatcherLink.java:412)
    at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleDiscrimination(HttpInboundLink.java:566)
    at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleNewRequest(HttpInboundLink.java:500)
    at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.processRequest(HttpInboundLink.java:360)
    at com.ibm.ws.http.channel.internal.inbound.HttpICLReadCallback.complete(HttpICLReadCallback.java:70)
    at com.ibm.ws.tcpchannel.internal.WorkQueueManager.requestComplete(WorkQueueManager.java:504)
    at com.ibm.ws.tcpchannel.internal.WorkQueueManager.attemptIO(WorkQueueManager.java:574)
    at com.ibm.ws.tcpchannel.internal.WorkQueueManager.workerRun(WorkQueueManager.java:958)
    at com.ibm.ws.tcpchannel.internal.WorkQueueManager$Worker.run(WorkQueueManager.java:1047)
    at com.ibm.ws.threading.internal.ExecutorServiceImpl$RunnableWrapper.run(ExecutorServiceImpl.java:238)
    at java.base\/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
    at java.base\/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
    at java.base\/java.lang.Thread.run(Thread.java:866)
Caused by: java.lang.NullPointerException
    at com.ibm.ws.webcontainer.security.internal.BasicAuthAuthenticator.getBasicAuthRealmName(BasicAuthAuthenticator.java:170)
    at com.ibm.ws.webcontainer.security.internal.BasicAuthAuthenticator.authenticate(BasicAuthAuthenticator.java:68)
    at com.ibm.ws.webcontainer.security.WebAuthenticatorProxy.authenticate(WebAuthenticatorProxy.java:88)
    at com.ibm.ws.webcontainer.security.WebAppSecurityCollaboratorImpl.authenticateRequest(WebAppSecurityCollaboratorImpl.java:1233)
    at com.ibm.ws.webcontainer.security.WebAppSecurityCollaboratorImpl.determineWebReply(WebAppSecurityCollaboratorImpl.java:989)
    at com.ibm.ws.webcontainer.security.WebAppSecurityCollaboratorImpl.performSecurityChecks(WebAppSecurityCollaboratorImpl.java:678)
    at com.ibm.ws.webcontainer.security.WebAppSecurityCollaboratorImpl.preInvoke(WebAppSecurityCollaboratorImpl.java:596)
    at com.ibm.wsspi.webcontainer.collaborator.CollaboratorHelper.preInvokeCollaborators(CollaboratorHelper.java:470)
    at com.ibm.ws.webcontainer.osgi.collaborator.CollaboratorHelperImpl.preInvokeCollaborators(CollaboratorHelperImpl.java:270)
    at com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1115)
    at com.ibm.ws.webcontainer.webapp.WebApp.handleRequest(WebApp.java:5049)
    ... 18 more
```

Moving up to 22.0.0.3 fixed this NPE.