### PR TITLE
Update the API contract for Trade History

### DIFF
--- a/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/broker/BrokerService.java
+++ b/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/broker/BrokerService.java
@@ -20,7 +20,8 @@ package com.ibm.hybrid.cloud.sample.stocktrader.broker;
 import com.ibm.hybrid.cloud.sample.stocktrader.broker.client.AccountClient;
 import com.ibm.hybrid.cloud.sample.stocktrader.broker.client.CashAccountClient;
 import com.ibm.hybrid.cloud.sample.stocktrader.broker.client.PortfolioClient;
-import com.ibm.hybrid.cloud.sample.stocktrader.broker.client.TradeHistoryClient;
+//import com.ibm.hybrid.cloud.sample.stocktrader.broker.client.TradeHistoryClient;
+import com.ibm.hybrid.cloud.sample.stocktrader.broker.client.tradehistory.TradeHistoryClient;
 import com.ibm.hybrid.cloud.sample.stocktrader.broker.json.Account;
 import com.ibm.hybrid.cloud.sample.stocktrader.broker.json.Broker;
 import com.ibm.hybrid.cloud.sample.stocktrader.broker.json.CashAccount;
@@ -44,7 +45,6 @@ import io.opentelemetry.context.Scope;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import jakarta.enterprise.context.RequestScoped;
 
 //mpConfig 1.3
 import jakarta.ws.rs.*;
@@ -427,7 +427,7 @@ public class BrokerService extends Application {
 		}
 
 		logger.fine("Getting portfolio returns");
-		String result = "Unknown";
+		Double result = null;
 		Portfolio portfolio = portfolioClient.getPortfolio(owner, true); //throws a 404 exception if not present
 		if (portfolio != null) {
 			Double portfolioValue = portfolio.getTotal();
@@ -442,7 +442,7 @@ public class BrokerService extends Application {
 		} else {
 			logger.warning("Portfolio not found to get returns for "+owner);
 		}
-		return result;
+		return String.valueOf(result);
 	}
 
 	@PUT

--- a/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/broker/client/TradeHistoryClient.java
+++ b/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/broker/client/TradeHistoryClient.java
@@ -39,6 +39,7 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 @RegisterClientHeaders //To enable JWT propagation
 // JWT is propagated.  See src/main/resources/META-INF/microprofile-config.properties
 /** mpRestClient "remote" interface for the trade history microservice */
+@Deprecated
 public interface TradeHistoryClient {
     @GET
     @Path("/returns/{owner}")

--- a/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/broker/client/tradehistory/Share.java
+++ b/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/broker/client/tradehistory/Share.java
@@ -1,0 +1,20 @@
+/*
+       Copyright 2025 Kyndryl, All Rights Reserved
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+package com.ibm.hybrid.cloud.sample.stocktrader.broker.client.tradehistory;
+
+/**
+ * Share record
+ */
+public record Share(String symbol, Integer shares) {
+}

--- a/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/broker/client/tradehistory/ShareEquity.java
+++ b/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/broker/client/tradehistory/ShareEquity.java
@@ -1,0 +1,20 @@
+/*
+       Copyright 2025 Kyndryl, All Rights Reserved
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+package com.ibm.hybrid.cloud.sample.stocktrader.broker.client.tradehistory;
+
+/**
+ * Share equity record
+ */
+public record ShareEquity(String symbol, Double equity) {
+}

--- a/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/broker/client/tradehistory/Shares.java
+++ b/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/broker/client/tradehistory/Shares.java
@@ -1,0 +1,25 @@
+/*
+       Copyright 2025 Kyndryl, All Rights Reserved
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+package com.ibm.hybrid.cloud.sample.stocktrader.broker.client.tradehistory;
+
+import java.util.List;
+
+/**
+ * Wrapper for a list of shares
+ */
+public record Shares(List<Share> shares) {
+}

--- a/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/broker/client/tradehistory/TradeHistoryClient.java
+++ b/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/broker/client/tradehistory/TradeHistoryClient.java
@@ -1,0 +1,76 @@
+/*
+       Copyright 2025 Kyndryl, All Rights Reserved
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+package com.ibm.hybrid.cloud.sample.stocktrader.broker.client.tradehistory;
+
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@ApplicationPath("/")
+@Path("/")
+@ApplicationScoped
+@RegisterRestClient
+@RegisterClientHeaders //To enable JWT propagation
+public interface TradeHistoryClient {
+
+    @GET
+    @Path("/returns/{owner}")
+    @Produces(MediaType.TEXT_PLAIN)
+    @WithSpan(kind = SpanKind.CLIENT, value = "TradeHistoryClient.getReturns")
+    Double getReturns(@PathParam("owner") String ownerName, @QueryParam("currentValue") Double portfolioValue);
+
+    @GET
+    @Path("/notional/{owner}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @WithSpan(kind = SpanKind.CLIENT, value = "TradeHistoryClient.getNotional")
+    Double getNotional(@PathParam("owner") String ownerName);
+
+    @Path("/shares/{owner}")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @WithSpan
+    Shares getPortfolioShares(@PathParam("owner") String ownerName);
+
+    @Path("/shares/{owner}/{symbol}")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @WithSpan
+    Share getCurrentShares(@PathParam("owner") String ownerName, @PathParam("symbol") String symbol);
+
+    @Path("/trades/{owner}/{symbol}")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @WithSpan
+    Transactions getTradesByOwnerAndSymbol(@PathParam("owner") String ownerName, @PathParam("symbol") String symbol);
+
+    @Path("/trades/{owner}")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @WithSpan
+    Transactions getTradesByOwner(@PathParam("owner") String ownerName);
+
+    @Path("/latestBuy")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @WithSpan
+    Transaction latestBuy();
+
+}

--- a/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/broker/client/tradehistory/Transaction.java
+++ b/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/broker/client/tradehistory/Transaction.java
@@ -1,0 +1,36 @@
+/*
+       Copyright 2025 Kyndryl, All Rights Reserved
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+package com.ibm.hybrid.cloud.sample.stocktrader.broker.client.tradehistory;
+
+import java.time.Instant;
+
+/**
+ * Transaction record
+ * The annotations are not needed on any JAX-RS or other clients as they are specific for the
+ * interacting only with the MongoDB driver
+ */
+public record Transaction(
+        String owner,
+        Integer shares,
+        String symbol,
+        Float notional,
+        Float price,
+        Float commission,
+        String _id,
+        Instant when
+) {
+}

--- a/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/broker/client/tradehistory/Transactions.java
+++ b/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/broker/client/tradehistory/Transactions.java
@@ -1,0 +1,25 @@
+/*
+       Copyright 2025 Kyndryl, All Rights Reserved
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+package com.ibm.hybrid.cloud.sample.stocktrader.broker.client.tradehistory;
+
+import java.util.List;
+
+/**
+ * Wrapper for a list of transactions
+ */
+public record Transactions(List<Transaction> transactions) {
+}


### PR DESCRIPTION
This is the corresponding broker PR for https://github.com/IBMStockTrader/trade-history/pull/72

This switches broker to use the updated API contract for trade-history, including the new client classes.